### PR TITLE
fix: low-severity cleanups from repo review

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -85,9 +85,6 @@ struct ErrorMessage {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
-        let body = Json(ErrorMessage {
-            message: self.to_string(),
-        });
         let status_code = match self {
             AppError::UnhandledDb(_)
             | AppError::Reqwest(_)
@@ -113,6 +110,15 @@ impl IntoResponse for AppError {
                 StatusCode::NOT_FOUND
             }
         };
+        // Internal error details (DB messages, upstream URLs, serialization dumps) are only
+        // logged server-side; clients get a generic message
+        let message = if status_code == StatusCode::INTERNAL_SERVER_ERROR {
+            tracing::error!("Internal error while handling a request: {}", self);
+            "Internal server error".to_string()
+        } else {
+            self.to_string()
+        };
+        let body = Json(ErrorMessage { message });
         (status_code, body).into_response()
     }
 }

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -148,17 +148,22 @@ pub async fn admin_login(
     State(state): State<Arc<AppState>>,
     Json(admin_login): Json<AdminLogin>,
 ) -> Result<String, AppError> {
-    if Argon2::default()
-        .verify_password(admin_login.password.as_bytes(), &ADMIN_PASSWORD)
-        .is_err()
-    {
+    let AdminLogin { password, id } = admin_login;
+    // Argon2 verification is CPU-heavy; run it off the async runtime thread
+    let password_correct = tokio::task::spawn_blocking(move || {
+        Argon2::default()
+            .verify_password(password.as_bytes(), &ADMIN_PASSWORD)
+            .is_ok()
+    })
+    .await?;
+    if !password_correct {
         return Err(AppError::WrongAdminPassword);
     }
 
     let client_credential_token = state.credentials_grant_client.get_access_token().await?;
     let osu_user = state
         .request
-        .get_user_osu(&client_credential_token, admin_login.id)
+        .get_user_osu(&client_credential_token, id)
         .await?;
 
     // Token can expire earlier than specified here. If that's the case, get a new one.
@@ -166,6 +171,6 @@ pub async fn admin_login(
         osu_user.id,
         osu_user.username.clone(),
         client_credential_token,
-        84600,
+        86400,
     )
 }

--- a/src/osu_api/cached_requester.rs
+++ b/src/osu_api/cached_requester.rs
@@ -80,7 +80,7 @@ impl CombinedRequester {
         let user_requester = Arc::new(CachedRequester::new(
             client.clone(),
             &format!("{}/api/v2/users", base_url),
-            24600,
+            21600,
         ));
         let beatmap_requester = Arc::new(CachedRequester::new(
             client.clone(),

--- a/src/osu_api/request.rs
+++ b/src/osu_api/request.rs
@@ -73,11 +73,14 @@ where
         access_token: &str,
         query: &str,
     ) -> Result<OsuSearchUserResponse, AppError> {
-        let search_url = format!(
-            "https://osu.ppy.sh/api/v2/search/?mode=user&query={}",
-            query
-        );
-        let res_body_bytes = self.get_request(&search_url, access_token).await?;
+        // parse_with_params percent-encodes the user-supplied query so special characters
+        // can't inject extra query parameters into the upstream request
+        let search_url = reqwest::Url::parse_with_params(
+            "https://osu.ppy.sh/api/v2/search/",
+            &[("mode", "user"), ("query", query)],
+        )
+        .map_err(|error| AppError::BadUri(error.to_string()))?;
+        let res_body_bytes = self.get_request(search_url.as_str(), access_token).await?;
         Ok(serde_json::from_slice(&res_body_bytes)?)
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -14,6 +14,12 @@ pub trait Retryable<Value: Send + Sync, Err: Error + Send>: Send {
                     return value;
                 }
                 Err(error) => {
+                    let fibo_temp = cooldown;
+                    cooldown += cooldown_fibo_last;
+                    if cooldown > longest_cooldown {
+                        cooldown = longest_cooldown;
+                    }
+                    cooldown_fibo_last = fibo_temp;
                     tracing::error!(
                         "{}. Trying to reconnect. Attempt {}, Cooldown {} secs. full error: {}",
                         message,
@@ -21,12 +27,6 @@ pub trait Retryable<Value: Send + Sync, Err: Error + Send>: Send {
                         cooldown,
                         error
                     );
-                    let fibo_temp = cooldown;
-                    cooldown += cooldown_fibo_last;
-                    if cooldown > longest_cooldown {
-                        cooldown = longest_cooldown;
-                    }
-                    cooldown_fibo_last = fibo_temp;
                     attempt += 1;
                     tokio::time::sleep(Duration::from_secs(cooldown.into())).await;
                 }


### PR DESCRIPTION
Six low-severity fixes from the same review that produced #27. **Stacked on #27** (base is its branch) - merge that first; GitHub will retarget this one to main automatically.

## Fixes
- **Admin JWT lifetime typo**: 84600 -> 86400, matching the cookie Max-Age used by the oauth flow (src/handlers/auth.rs).
- **User cache expiry typo**: 24600 -> 21600 in CombinedRequester, matching cached_osu_user_request for the same data (src/osu_api/cached_requester.rs).
- **500 bodies no longer leak internals**: DB/upstream error strings were returned to clients verbatim; now logged server-side via tracing and clients get a generic message (src/error.rs).
- **Argon2 verify off the runtime thread**: admin login (unauthenticated endpoint) ran CPU-heavy password hashing on the async runtime; moved to spawn_blocking (src/handlers/auth.rs).
- **Percent-encode user search query**: query was interpolated raw into the upstream osu! URL, letting special characters inject query params; now built with Url::parse_with_params (src/osu_api/request.rs).
- **Retry backoff log accuracy**: logged the previous iteration cooldown instead of the one actually slept (src/retry.rs).

Intentionally NOT included (behavior-changing, need a maintainer call): pagination default limit (u32::MAX today), CORS very_permissive, logout-as-GET.

## Verification
cargo build + cargo clippy --all-targets clean (only pre-existing warnings). Integration tests compile; not run (no Docker here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)