### PR TITLE
fix: surface SurrealDB statement errors on fire-and-forget writes

### DIFF
--- a/src/database/activity.rs
+++ b/src/database/activity.rs
@@ -23,7 +23,8 @@ impl DatabaseClient {
                 "#,
             )
             .bind(("user", numerical_thing("user", user_id)))
-            .await?;
+            .await?
+            .check()?;
         Ok(())
     }
 

--- a/src/database/user.rs
+++ b/src/database/user.rs
@@ -197,7 +197,8 @@ impl DatabaseClient {
                 "pending_beatmapset_count",
                 user_details.pending_beatmapset_count,
             ))
-            .await?;
+            .await?
+            .check()?;
         Ok(())
     }
 
@@ -205,7 +206,8 @@ impl DatabaseClient {
         self.db
             .query("UPDATE $thing SET authenticated = true")
             .bind(("thing", numerical_thing("user", user_id)))
-            .await?;
+            .await?
+            .check()?;
         Ok(())
     }
 
@@ -302,7 +304,8 @@ impl DatabaseClient {
             .bind(("order_array", enumerated_array))
             .query("UPDATE $thing SET updated_at = time::now()")
             .bind(("thing", numerical_thing("user", user_id)))
-            .await?;
+            .await?
+            .check()?;
         Ok(())
     }
 


### PR DESCRIPTION
Finding #8 from the backend review. Backend-only, no behavior change on the success path.

## Problem
`upsert_user`, `set_authenticated`, `set_influence_order` (src/database/user.rs) and `add_login_activity` (src/database/activity.rs) awaited the query `Response` but never inspected it. In SurrealDB a statement-level failure (constraint violation, bad field, type error) is carried **inside** the `Response`, not raised by `.await?`. So a failed write returned `Ok(())`, the handler returned 200, and the data was silently not persisted.

## Fix
Append `.check()?` to each of the four writes so statement errors propagate as `AppError::UnhandledDb` (500) instead of being swallowed.

## Verification
`cargo clippy --all-features -- -D warnings` and `cargo fmt --check` clean. Integration tests compile; not run here (no Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)