### PR TITLE
fix: check osu! API response status before decoding

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,9 @@ pub enum AppError {
     #[error("Unhandled Reqwest Error: {0}")]
     Reqwest(#[from] reqwest::Error),
 
+    #[error("osu! API returned an error status: {0}")]
+    OsuApiStatus(u16),
+
     #[error("Failed to decode json text: {0}")]
     SerdeJson(#[from] serde_json::Error),
 
@@ -109,6 +112,14 @@ impl IntoResponse for AppError {
             AppError::MissingInfluence | AppError::MissingUser(_) | Self::NonExistingMap(_) => {
                 StatusCode::NOT_FOUND
             }
+            // Translate an upstream osu! API status into something meaningful for our clients.
+            // 401/403 mean our own credentials failed, so it's a gateway problem, not the
+            // caller's.
+            AppError::OsuApiStatus(status) => match status {
+                404 => StatusCode::NOT_FOUND,
+                429 => StatusCode::TOO_MANY_REQUESTS,
+                _ => StatusCode::BAD_GATEWAY,
+            },
         };
         // Internal error details (DB messages, upstream URLs, serialization dumps) are only
         // logged server-side; clients get a generic message

--- a/src/osu_api/request.rs
+++ b/src/osu_api/request.rs
@@ -184,12 +184,22 @@ impl Requester for OsuApiRequestClient {
 
         let _permit = self.semaphore.acquire().await?;
         let res = self.client.get(url).headers(headers).send().await?;
+        let status = res.status();
+        if !status.is_success() {
+            // osu! error responses carry an unrelated JSON body, so returning it here would
+            // surface later as a confusing deserialization error. Fail early with the status.
+            return Err(AppError::OsuApiStatus(status.as_u16()));
+        }
         Ok(res.bytes().await?)
     }
 
     async fn post_request(&self, url: &str, body: AuthRequest) -> Result<Bytes, AppError> {
         let _permit = self.semaphore.acquire().await?;
         let res = self.client.post(url).json(&body).send().await?;
+        let status = res.status();
+        if !status.is_success() {
+            return Err(AppError::OsuApiStatus(status.as_u16()));
+        }
         Ok(res.bytes().await?)
     }
 }


### PR DESCRIPTION
Finding #10 from the backend review. Backend-only. Pairs with the timeout added in #27.

## Problem
`get_request`/`post_request` (src/osu_api/request.rs) returned the response body regardless of HTTP status. When osu! replied 404/401/429 the body is an osu! *error* JSON, which then failed downstream as a serde `Failed to decode json text` error and surfaced to clients as a misleading **500**. Rate limiting (429) was completely invisible — it looked like corrupt upstream data.

## Fix
Check `res.status()` after `send()`. Non-2xx returns a new `AppError::OsuApiStatus(u16)`, mapped for our clients:
- `404` -> Not Found
- `429` -> Too Many Requests
- everything else (incl. 401/403, which mean *our* credentials failed, not the caller's) -> Bad Gateway

Success path is unchanged. Only the real `OsuApiRequestClient` is affected; the test client overrides these methods, so integration tests are unaffected.

## Verification
`cargo clippy --all-features -- -D warnings` and `cargo fmt --check` clean. Tests compile; not run here (no Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)