### PR TITLE
fix: clean up websocket tasks and tolerate broadcast lag

### DIFF
--- a/src/handlers/activity.rs
+++ b/src/handlers/activity.rs
@@ -495,7 +495,7 @@ async fn handle_socket(
     }
     let ws_sender_clone = Arc::clone(&ws_sender);
 
-    let websocket_task = tokio::spawn(async move {
+    let mut websocket_task = tokio::spawn(async move {
         loop {
             match ws_receiver.next().await {
                 Some(Ok(_)) => {
@@ -517,7 +517,7 @@ async fn handle_socket(
         }
     });
 
-    let broadcast_task = tokio::spawn(async move {
+    let mut broadcast_task = tokio::spawn(async move {
         loop {
             match broadcast_receiver.recv().await {
                 Ok(new_activity_string) => {
@@ -530,17 +530,28 @@ async fn handle_socket(
                         break;
                     }
                 }
-                Err(error) => {
-                    tracing::error!("Error receiving broadcast message: {}", error);
+                // A slow client can fall behind the bounded broadcast channel. That's not fatal:
+                // skip the dropped messages and keep serving instead of silently killing the feed.
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::warn!(
+                        "Websocket for {} lagged behind, skipped {} activities",
+                        address,
+                        skipped
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("Broadcast channel closed for {}", address);
                     break;
                 }
             }
         }
     });
 
+    // Whichever task finishes first (client disconnect or channel close), abort the other so it
+    // doesn't linger holding a broadcast receiver / sender half.
     tokio::select! {
-        _ = websocket_task => {},
-        _ = broadcast_task => {},
+        _ = &mut websocket_task => broadcast_task.abort(),
+        _ = &mut broadcast_task => websocket_task.abort(),
     }
 }
 


### PR DESCRIPTION
Finding #9 from the backend review. Backend-only, `src/handlers/activity.rs`.

## Problems
**Leaked task on disconnect.** `handle_socket` spawns a read task and a broadcast task, then `tokio::select!`s over both `JoinHandle`s. `select!` returns when the first completes but never aborts the other. On client disconnect the read task ends and the function returns, yet the broadcast task keeps running — holding a broadcast `Receiver` — until its next send happens to fail. Every disconnect leaks a task for a while.

**Lag kills the feed silently.** The broadcast channel is bounded (capacity 50). A client that briefly falls behind gets `RecvError::Lagged`, which the code treated as fatal (`break`). The socket stays open but never receives another activity — a silently dead feed.

## Fix
- After `select!`, `.abort()` the surviving task (handles made `mut` so they can be polled by `&mut` in the select).
- Match the recv error: on `Lagged(n)` log a warning and continue; only `break` on `Closed`.

## Verification
`cargo clippy --all-features -- -D warnings` and `cargo fmt --check` clean. Tests compile; not run here (no Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)